### PR TITLE
Engine: Fix loading maps from a non-trivial relative path

### DIFF
--- a/src/OpenH2.Engine/Engine.cs
+++ b/src/OpenH2.Engine/Engine.cs
@@ -61,27 +61,29 @@ namespace OpenH2.Engine
 
             var factory = new MapFactory(Path.GetDirectoryName(mapPath));
 
+            var mapFilename = Path.GetFileName(mapPath);
+
             matFactory.AddListener(() =>
             {
-                LoadMap(factory, mapPath, matFactory);
+                LoadMap(factory, mapFilename, matFactory);
             });
 
             world = new RealtimeWorld(gameWindowGetter(), 
                 audioHost.GetAudioAdapter(), 
                 graphicsHost);
 
-            LoadMap(factory, mapPath, matFactory);
+            LoadMap(factory, mapFilename, matFactory);
 
             gameLoop.RegisterCallbacks(world.Update, world.Render);
             gameLoop.Start(60, 60);
         }
 
-        private void LoadMap(MapFactory factory, string mapPath, IMaterialFactory materialFactory)
+        private void LoadMap(MapFactory factory, string mapFilename, IMaterialFactory materialFactory)
         {
             var watch = new Stopwatch();
             watch.Start();
 
-            var imap = factory.Load(mapPath);
+            var imap = factory.Load(mapFilename);
 
             if(imap is not H2vMap map)
             {


### PR DESCRIPTION
If the map path is set to something like "maps\00a_introduction.map", the "maps\" directory is given to MapFactory (line 62), so when `factory.Load(mapPath)` is run, it will attempt to load "maps\maps\00a_introduction.map". So what we should probably be doing is calling `Load` on the map filename, not its full path.